### PR TITLE
fix: fix missing parameters in get_current_user

### DIFF
--- a/app/utils/user.py
+++ b/app/utils/user.py
@@ -115,7 +115,7 @@ def authenticate_user(username: str, password: str, session: Session):
     return user
 
 
-def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]):
+def get_current_user(token: Annotated[str, Depends(oauth2_scheme)], session: Session):
     """
     Verifies the provided token and returns the corresponding user.
 
@@ -143,7 +143,7 @@ def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]):
         token_data = TokenData(username=username)
     except JWTError:
         raise credentials_exception
-    user = get_user_by_username(token_data.username)
+    user = get_user_by_username(token_data.username, session)
 
     if user is None:
         raise credentials_exception


### PR DESCRIPTION
### What does this PR do?

- Adds `session` as parameter to `get_current_user` to pass it as a missing argument to `get_user_by_username`.

### Related issue?
- Resolves #77 