### PR TITLE
feat: add login route server redirect

### DIFF
--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -12,11 +12,20 @@
     </div>
 
     <div class="form-container">
-        <form id="login-form" hx-post="/login" hx-swap="innerHTML">
+        <form id="login-form" hx-post="/login">
             <input type="text" name="username" placeholder="Username">
             <input type="password" name="password" placeholder="Password">
             <button type="submit">Login</button>
         </form>
     </div>
+
+    <script>
+        document.body.addEventListener('htmx:afterRequest', (event) => {
+            const redirectUrl = event.detail.xhr.getResponseHeader('HX-Redirect');
+            if (redirectUrl) {
+                window.location.href = redirectUrl;
+            }
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
### What does this PR do?
- Adds redirect to index page after successful login on server
- Adds HX-Redirect header to "/" for client redirect handling
- Adds token to cookie so that it's sent automatically with every request

### Related issue?
- Resolves #76 