### PR TITLE
bug: fix testing environment configs

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -13,7 +13,6 @@ async def lifespan(app: FastAPI):
     # Initialize the database
     init_db()
     yield
-    # Cleanup or shutdown logic can be added here if needed
 
 
 def create_app() -> FastAPI:

--- a/app/config.py
+++ b/app/config.py
@@ -1,3 +1,5 @@
+import os
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -10,7 +12,7 @@ class Settings(BaseSettings):
     secret_key: str
     encryption_algo: str
 
-    model_config = SettingsConfigDict(env_file=".env")
+    model_config = SettingsConfigDict(env_file="/.env")
 
 
 class TestSettings(BaseSettings):
@@ -20,4 +22,8 @@ class TestSettings(BaseSettings):
     db_host: str
     db_port: str
 
-    model_config = SettingsConfigDict(env_file=".env.test")
+    model_config = SettingsConfigDict(
+        env_file=os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", ".env.test")
+        )
+    )

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,3 +1,4 @@
+import os
 from functools import lru_cache
 
 from .config import Settings, TestSettings
@@ -21,6 +22,6 @@ def get_settings():
     return Settings()
 
 
-@lru_cache()
 def get_test_settings():
+    print(f"Current working directory: {os.getcwd()}")
     return TestSettings()

--- a/compose.yaml
+++ b/compose.yaml
@@ -25,5 +25,15 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+
+  test_db:
+    image: postgres:13
+    environment:
+      POSTGRES_DB: fastapi_todo_test_db
+      POSTGRES_USER: test_user
+      POSTGRES_PASSWORD: test_password
+    ports:
+      - 5434:5432
+
 volumes:
   pg-data:

--- a/tests/test_todos.py
+++ b/tests/test_todos.py
@@ -77,3 +77,8 @@ def test_delete_todo(client, override_session, logged_in_user):
     response = client.get("/todos", cookies=cookies)
     assert response.status_code == 200
     assert "Delete Todo" not in response.text
+
+
+def test_db_connection(override_session):
+    print(f"Connected to database: {override_session.bind.url}")
+    assert "test_db" in str(override_session.bind.url)


### PR DESCRIPTION
### What does this PR do?
- Refactors test configs on `postgres_db` url
- Creates a separate postgres service for the test db to ensure **isolation**: ensures that tests do not interfere with your development or production databases.

### Related issue?
- N/A